### PR TITLE
add options for list & hr output

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -210,6 +210,15 @@
                     <li>
                       <a href="#options-postprocess">postprocess</a>
                     </li>
+                    <li>
+                      <a href="#options-bullets">bullets</a>
+                    </li>
+                    <li>
+                      <a href="#options-indent">indent</a>
+                    </li>
+                    <li>
+                      <a href="#options-hr">hr</a>
+                    </li>
                   </ul>
                 </li>
                 <li>
@@ -802,6 +811,33 @@ Options:
             </h3>
             <p>TODO</p>
             <p></p>
+            <h3 id="options-bullets">bullets
+              <a href="#options-bullets" name="options-bullets" class="anchor">
+                <span class="anchor-target" id="options-bullets"></span>
+                <span class="glyphicon glyphicon-link"></span>
+              </a>
+            </h3>
+            <p>Type: <code>string[]</code></p>
+            <p>Default: <code>['*', '-', '+']</code></p>
+            <p>Bullets to use for unordered lists.</p>
+            <h3 id="options-indent">indent
+              <a href="#options-indent" name="options-indent" class="anchor">
+                <span class="anchor-target" id="options-indent"></span>
+                <span class="glyphicon glyphicon-link"></span>
+              </a>
+            </h3>
+            <p>Type: <code>number</code></p>
+            <p>Default: <code>2</code></p>
+            <p>Number of spaces to indent nested lists (ordered and unordered).</p>
+            <h3 id="options-hr">hr
+              <a href="#options-hr" name="options-hr" class="anchor">
+                <span class="anchor-target" id="options-hr"></span>
+                <span class="glyphicon glyphicon-link"></span>
+              </a>
+            </h3>
+            <p>Type: <code>string</code></p>
+            <p>Default: <code>'***'</code></p>
+            <p>Markdown string to use for horizontal rules.</p>
             <h2 id="customizing">Customizing
               <a href="#customizing" name="customizing" class="anchor">
                 <span class="anchor-target" id="customizing"></span>

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -9,21 +9,32 @@ var define = require('define-property');
 var repeat = require('repeat-string');
 var condense = require('condense-newlines');
 var unescape = require('unescape');
+var merge = require('mixin-deep');
 var handlers = require('./handlers/');
 var tables = require('./tables');
 var block = utils.block;
+var defaults = {
+  bullets: ['*', '-', '+'],
+  indent: 2,
+  hr: '***'
+};
 
 /**
  * Register snapdragon compilers
  */
 
 module.exports = function(breakdance, options) {
-  options = options || {};
+  options = merge({}, defaults, options);
+
+  // if user passes in a single string instead of an array
+  if (typeof options.bullets === 'string') {
+    options.bullets = [options.bullets];
+  }
 
   return function(compiler) {
     // inside this function, "this" is the snapdragon instance
 
-    var bullets = ['*', '-', '+'];
+    var indentString = ' '.repeat(this.options.indent);
     var visit = compiler.visit;
     var before = breakdance.run('before', compiler);
     var after = breakdance.run('after', compiler);
@@ -187,7 +198,7 @@ module.exports = function(breakdance, options) {
        */
 
       .set('hr', function(node) {
-        this.emit('\n\n***\n\n');
+        this.emit('\n\n' + this.options.hr + '\n\n');
       })
 
       /**
@@ -319,12 +330,12 @@ module.exports = function(breakdance, options) {
         this.mapVisit(node);
       })
       .set('ol.open', function(node) {
-        if (this.state.lists.length) this.state.indent += '  ';
+        if (this.state.lists.length) this.state.indent += indentString;
         this.state.lists.push('ol');
         this.state.ol.push(1);
       })
       .set('ol.close', function(node) {
-        this.state.indent = this.state.indent.slice(2);
+        this.state.indent = this.state.indent.slice(this.options.indent);
         this.state.lists.pop();
         this.state.ol.pop();
         if (!this.state.lists.length) {
@@ -346,11 +357,11 @@ module.exports = function(breakdance, options) {
         this.mapVisit(node);
       })
       .set('ul.open', function(node) {
-        if (this.state.lists.length) this.state.indent += '  ';
+        if (this.state.lists.length) this.state.indent += indentString;
         this.state.lists.push('ul');
       })
       .set('ul.close', function(node) {
-        this.state.indent = this.state.indent.slice(2);
+        this.state.indent = this.state.indent.slice(this.options.indent);
         this.state.lists.pop();
         if (!this.state.lists.length) {
           var newline = node.parent.newline;
@@ -389,7 +400,7 @@ module.exports = function(breakdance, options) {
             this.state.ol.push(n);
           }
         } else {
-          ch = bullets[(len ? len - 1 : 0) % bullets.length];
+          ch = this.options.bullets[(len ? len - 1 : 0) % this.options.bullets.length];
         }
 
         // emit indentation and bullet


### PR DESCRIPTION
added options, with current behavior as default, for formatting lists & HRs... for example, I could then add this to my options...

```js
{
    "hr": '---',
    "bullets": '-',
    "indent": 4
}
```

to have sublists indented 4 spaces instead of 2 and to have all ULs use `-` regardless of level... thus I can set Breakdance to output in compliance with my .markdownlintrc
